### PR TITLE
Add lazy 'Auth0' property to authz api context.

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,14 @@ function extend (api) {
     }
   });
   
+  Object.defineProperty(api, 'Auth0', {
+    configurable: false,
+    enumerable: true,
+    get: function (){
+      return require('auth0');
+    }
+  });
+  
   Object.defineProperty(api, 'sqlserver', {
     configurable: false,
     enumerable: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-rules-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[auth0/auth0-server](https://github.com/auth0/auth0-server) requires that the `Auth0` constructor be available in the sandboxed global context.