### PR TITLE
Ensure that Buffer is available in secure_sandbox and eval strategies

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ function extend (api) {
 
   api.__auth0_api = true;
 
+  api.Buffer = Buffer;
   api.mongo = mongo;
   api.mysql = mysql;
   api.mysql_pool = mysql_pool;


### PR DESCRIPTION
For the appliance, using either the `eval` or `secure_sandbox` strategies, `Buffer` is not defined in the custom execution context.

![image](https://cloud.githubusercontent.com/assets/50030/11690284/eceeef1e-9e63-11e5-86f8-b94de9802531.png)

This PR makes sure it is available.