### PR TITLE
Do not rely on `require.__verquire` to use specific module versions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,10 +230,14 @@ function extend (api) {
     configurable: false,
     enumerable: true,
     get:  function () {
-      var tediousSpec = require.__verquire
-        ? 'tedious@0.1.4'
-        : 'tedious';
-      var tedious = require(tediousSpec);
+      var tedious;
+      
+      try {
+        tedious = require('tedious@0.1.4');
+      } catch (__) {
+        tedious = require('tedious');
+      }
+      
       var sqlserver = {
         connect: function (config) {
           var Connection = tedious.Connection;
@@ -322,10 +326,15 @@ function extend (api) {
     configurable: false,
     enumerable: true,
     get: function () {
-      var xtendSpec = require.__verquire
-        ? 'xtend@1.0.3'
-        : 'xtend';
-      return require(xtendSpec);
+      var xtend;
+      
+      try {
+        xtend = require('xtend@1.0.3');
+      } catch (__) {
+        xtend = require('xtend');
+      }
+      
+      return xtend;
     }
   });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,6 +7,7 @@ var expect = Code.expect;
 
 var expectedFields = [
     '__auth0_api',
+    'Buffer',
     'mongo',
     'mysql',
     'mysql_pool',


### PR DESCRIPTION
`require.__verquire` appears to be returning truthy in situations where `verquire` support is not available. Instead of relying on this, attempt first to load the specific module version via `verquire` spec and then fallback to normal `require`.