### PR TITLE
Use pg built-in conn pooling instead of manual Client

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,11 +125,8 @@ function mysql_pool (options) {
 
 function postgres (connString, callback) {
   var pg = require('pg');
-  var client = new pg.Client(connString);
-  client.connect(function(err) {
-    if (err) return callback(err);
-    callback(null, client);
-  });
+  
+  pg.connect(connString, callback);
 }
 
 // Allow consumers of the module to expose the api on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-rules-api",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Tested in Vagrant instance by replicating the code path (but not by creating a custom sandbox w/ a new version of this library pre-provisioned).

Test code was:

```js
function (user, context, callback) {
  const Pg = require('pg');
  
  Pg.connect('postgres://postgres:postgres@192.168.42.1:5432/postgres', function (err, client, done) {
    if (err) {
      console.log(err.message);
      return callback(err);
    }
    
    client.query('SELECT * FROM pg_catalog.pg_tables', function (err, result) {
      done();
      
      if (err) {
        console.log(err.message);
        return callback(err);
      }
      
      console.log(result);
      
      callback(null, user, context);
    });
  });
}```

in a rule.