### PR TITLE
Update couchbase to 2.1.3 to match webtask platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-rules-api",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "auth0": "^2.0.0-alpha.5",
     "azure-storage": "~0.4.1",
     "bcrypt": "~0.8.3",
-    "couchbase": "~1.2.1",
+    "couchbase": "~2.1.3",
     "easy-pbkdf2": "0.0.2",
     "jsonwebtoken": "~0.4.1",
     "knex": "~0.6.3",


### PR DESCRIPTION
This PR updates the version of **couchbase** that is available as a pseudo-global in Auth0 rules to `2.1.3`. This update is necessary to reflect that fact that `1.2.1` has not been building in node `4.x` since we made the switch to `4.x`. In other words, all cloud sandbox customers have been using `2.1.3` all along (see below) but this is not the case for appliance customers.

**How did tests even pass, then?**

Two things were conspiring to allow tests to pass:

1. The webtask base image had version `2.1.3` in its collection of bundled modules: https://github.com/auth0/webtask-base/blame/v1.0.25/packages.json#L431
2. The webtask `Dockerfile` took a manual step to wipe out the `1.2.1` version included with this module during the build: https://github.com/auth0/webtask/blame/4.13.0/Dockerfile#L15

**Risks for appliance customers**

* Appliance customers do not yet use the docker-based webtask appliance and so they are using this module directly via `node-sandbox` or `eval`.
* Customers may still be running on `0.10.x`, or `0.12.x` or ... and may depend on specifics of the `1.2.x` minor.