### PR TITLE
Re-introduce decode property of jwt magic global

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,7 @@ function extend (api) {
         const jwt = require('jsonwebtoken');
 
         jwtMagicGlobal = {
+          decode: jwt.decode,
           sign: (payload, secret, options) => {
             var newOptions = options;
             if (newOptions && newOptions.expiresInMinutes) {


### PR DESCRIPTION
Before #17, the `jwt` magic global was a direct proxy for `jsonwebtoken@~0.4.1` which exposed a `.decode` method: https://github.com/auth0/node-jsonwebtoken/blob/342b86c49968bc1bfbdf985e83d83d0d3bd5e220/index.js#L3-L5.

When we bumped to `jsonwebtoken@~7.4.1`, this method was lost. This PR re-adds the missing method.