### PR TITLE
[DXEX-429] - Update dependencies to run on node 12.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2.1
+jobs:
+  build_and_test:
+    working_directory: ~/repo
+    parameters:
+      v:
+        type: string
+        default: "8"
+    docker:
+      - image: circleci/node:<< parameters.v >>
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm test
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+  deploy:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish
+
+workflows:
+  version: 2.1
+  build_and_test:
+    jobs:
+      - build_and_test:
+          name: build_and_test_node8
+          v: "8"
+      - build_and_test:
+          name: build_and_test_node12
+          v: "12"
+  build_test_and_deploy:
+    jobs:
+      - build_and_test:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ workflows:
       - build_and_test:
           name: build_and_test_node12
           v: "12"
+      - build_and_test:
+          name: build_and_test_node13
+          v: "13"
   build_test_and_deploy:
     jobs:
       - build_and_test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-rules-api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "async": "~0.9.0",
     "auth0": "2.0.0-alpha.6",
     "azure-storage": "~2.2.1",
-    "bcrypt": "1.0.3",
-    "couchbase": "~2.5.1",
+    "bcrypt": "^3.0.8",
+    "couchbase": "^2.6.10",
     "easy-pbkdf2": "0.0.2",
     "jsonwebtoken": "~7.4.1",
     "knex": "~0.13.0",
@@ -36,8 +36,8 @@
   "license": "MIT",
   "homepage": "https://github.com/auth0/auth0-authz-rules-api",
   "devDependencies": {
-    "code": "^1.5.0",
+    "@hapi/code": "^8.0.1",
     "eslint": "^4.19.1",
-    "lab": "^5.14.0"
+    "@hapi/lab": "^22.0.3"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,5 @@
-var Code = require('code');
-var Lab = require('lab');
+const Code = require("@hapi/code");
+const Lab = require("@hapi/lab");
 var Api = require('../');
 
 var lab = exports.lab = Lab.script();
@@ -77,14 +77,13 @@ var errorClasses = {
 };
 
 lab.experiment('The exposed api', {parallel: true}, function () {
-    lab.test('has all expected fields', function (done) {
+    lab.test('has all expected fields', function () {
         expect(Object.keys(Api.api)).to.only.include(expectedFields);
-        done();
     });
 });
 
 lab.experiment('The api exposes Error classes', {parallel: true}, function () {
-    lab.test('that inherit from Error', function (done) {
+    lab.test('that inherit from Error', function () {
         Object.keys(errorClasses).forEach(function (errorClass) {
             var fixture = errorClasses[errorClass];
             var constructor = Api.api[errorClass];
@@ -97,10 +96,9 @@ lab.experiment('The api exposes Error classes', {parallel: true}, function () {
             expect(err).to.be.an.instanceof(constructor);
         });
 
-        done();
     });
 
-    lab.test('that have common fields', function (done) {
+    lab.test('that have common fields', function () {
         Object.keys(errorClasses).forEach(function (errorClass) {
             var fixture = errorClasses[errorClass];
             var constructor = Api.api[errorClass];
@@ -114,10 +112,9 @@ lab.experiment('The api exposes Error classes', {parallel: true}, function () {
             expect(err.statusCode).to.be.a.number();
         });
 
-        done();
     });
 
-    lab.test('that have all expected fields with the correct values', function (done) {
+    lab.test('that have all expected fields with the correct values', function () {
         Object.keys(errorClasses).forEach(function (errorClass) {
             var fixture = errorClasses[errorClass];
             var constructor = Api.api[errorClass];
@@ -133,21 +130,19 @@ lab.experiment('The api exposes Error classes', {parallel: true}, function () {
             });
         });
 
-        done();
     });
 });
 
 lab.experiment('Api extension', {parallel: true}, function () {
-    lab.test('can be used to expose the api on any object', function (done) {
+    lab.test('can be used to expose the api on any object', function () {
         var foo = {};
 
         Api.extend(foo);
 
         expect(Object.keys(foo)).to.only.include(expectedFields);
-        done();
     });
 
-    lab.test('will not extend a given object twice', function (done) {
+    lab.test('will not extend a given object twice', function () {
         var foo = {};
 
         Api.extend(foo);
@@ -161,7 +156,5 @@ lab.experiment('Api extension', {parallel: true}, function () {
 
         expect(foo.mongo).to.equal('mongooooo!!');
         expect(foo.mongo).to.not.equal(apiMongo);
-
-        done();
     });
 });


### PR DESCRIPTION
### Description

This change attempts to provide webtask with node 12 compatible magic globals with minimal breakage.

The following magic globals needs to be updated:

**bcrypt**
`bcrypt@1.0.3` build fails.
Updating to latest `3.0.8` works.
Breaking changes: v1 to v2 may contain breaking changes to hashing (node.bcrypt.js/CHANGELOG.md at master · kelektiv/node.bcrypt.js · GitHub)

**couchbase**
`couchbase@2.5.1` build fails.
Updating to `2.6.10` works.
No breaking change, however 3.0.0 exists.

The following dev dependencies needs to be upgraded for tests to work:

**lab** and **code**
Will build on node 12 but does not run tests. Update the following for tests to pass:

- lab package to  `@hapi/lab@22.0.3`
- code package to  `@hapi/code@8.0.1`

#### Summary
The following magic global updates are required to build the library on node 12:
1. bcrypt@3.0.8
2. couchbase@2.6.10

### References

https://auth0team.atlassian.net/browse/DXEX-429

### Testing

Pull this change into webtask and execute rules that have usages of the magic globals that changed.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
